### PR TITLE
taimen: Revert to March 2018 build fingerprint

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -1,5 +1,5 @@
 # Pixel identification
-ro.build.fingerprint=google/taimen/taimen:11/RP1A.201005.004.A1/6934943:user/release-keys
+ro.build.fingerprint=google/taimen/taimen:8.1.0/OPM1.171019.021/4565141:user/release-keys
 ro.product.manufacturer=Google
 ro.product.device=taimen
 ro.product.brand=google


### PR DESCRIPTION
It has been observed that the SafetyNet ctsProfile match cannot works with SPL which are 3 months ahead from the build fingerprint.

As the last build fingerprint for taimen is from Dec 2020 which means we cannot pass SafetyNet if we use SPL which are ahead of March 2021.

As observed in I25ba2b87d9be485742d4c25ee51a31ede269a540 using a March 2018 or older build fingerprint results in ctsProfile check not caring about SPL date.

Alternatively, We can also spoof build fingerprint from latest Pixel device.